### PR TITLE
support test with nhwc layout and 32-bit data type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,5 +54,14 @@ jobs:
           export CI=true
           source ${ENV_PATH}/github_bashrc && source /mnt/cache/share/platform/env/${ENV_NAME} && cd ${NFS_PATH}/${GITHUB_RUN_NUMBER} && cd ${GITHUB_JOB}
           srun --job-name=${GITHUB_JOB} --partition=${SLURM_PAR_SH1984} --time=40 --gres=gpu:${GPU_REQUESTS} bash -c 'cd python && python main.py --mode gen_data && python main.py --mode run_test'
+          """
+      - name: NHWC-32bit-test
+        run: |
+          ssh ${CLUSTER_1984} """
+          set -e
+          export CI=true
+          source ${ENV_PATH}/github_bashrc && source /mnt/cache/share/platform/env/${ENV_NAME} && cd ${NFS_PATH}/${GITHUB_RUN_NUMBER} && cd ${GITHUB_JOB}
+          srun --job-name=${GITHUB_JOB} --partition=${SLURM_PAR_SH1984} --time=40 --gres=gpu:${GPU_REQUESTS} bash -c 'cd python && python main.py --mode run_test --fname batch_norm --nhwc &&
+          python main.py --mode run_test --fname index_select --four_bytes && python main.py --mode run_test --fname arange --four_bytes'
           cd ${NFS_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf ${GITHUB_JOB}
           """

--- a/python/conformance/diopi_functions.py
+++ b/python/conformance/diopi_functions.py
@@ -2,8 +2,8 @@
 import math
 
 from ctypes import c_float, c_double, c_int64, c_int32, c_bool, c_void_p, byref, pointer
-from .diopi_runtime import Sizes, Scalar, Tensor, TensorHandle
-from .utils import check_returncode, check_function
+from .diopi_runtime import Sizes, Scalar, Tensor, TensorHandle, compute_nhwc_stride, compute_nhwc_stride_2d, compute_nhwc_stride_3d
+from .utils import check_returncode, check_function, glob_vars
 from . import Dtype, raw_like
 from collections import namedtuple
 import numpy as np
@@ -483,7 +483,7 @@ def min(input, dim=0, keepdim=False) -> Tensor:
     else:
         del sizeI[dim]
     out = Tensor(sizeI, input.get_dtype())
-    indices = Tensor(out.size(), Dtype.int64)
+    indices = Tensor(out.size(), glob_vars.int_type)
     func = check_function("diopiMin")
 
     ret = func(input.context_handle, out.tensor_handle, indices.tensor_handle,
@@ -653,7 +653,8 @@ def conv2d(input, weight, bias=None, stride=1,
     padding = Sizes(tuple(padding))
     dilation = Sizes(tuple(dilation))
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     func = check_function("diopiConvolution2d")
     ret = func(input.context_handle, out.tensor_handle, input.tensor_handle,
                weight.tensor_handle, bias, stride, padding, dilation, groups)
@@ -688,7 +689,8 @@ def avg_pool2d(input, kernel_size, stride=None, padding=0, ceil_mode=False,
     stride = Sizes(tuple(stride))
     padding = Sizes(tuple(padding))
     kernel_size = Sizes(tuple(kernel_size))
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
 
     if divisor_override is None:
         divisor_override = c_void_p()
@@ -737,7 +739,8 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
     padding = Sizes(tuple(padding))
     kernel_size = Sizes(tuple(kernel_size))
     dilation = Sizes(tuple(dilation))
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
 
     if not return_indices:
         func = check_function("diopiMaxPool2d")
@@ -748,7 +751,8 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
         return out
     else:
         func = check_function("diopiMaxPool2dWithIndices")
-        indices = Tensor(sizeO, Dtype.int64)
+        nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+        indices = Tensor(sizeO, glob_vars.int_type, stride=nhwc_stride)
         ret = func(input.context_handle, out.tensor_handle,
                    indices.tensor_handle, input.tensor_handle,
                    kernel_size, stride, padding, dilation, ceil_mode)
@@ -775,7 +779,8 @@ def adaptive_avg_pool2d(input, output_size):
         else:
             sizeO.append(output_size[i])
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     output_size = Sizes((sizeO[-2], sizeO[-1]))
 
     func = check_function("diopiAdaptiveAvgPool2d")
@@ -804,12 +809,14 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
         else:
             sizeO.append(output_size[i])
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     output_size = Sizes(tuple(output_size))
 
     if return_indices:
         func = check_function("diopiAdaptiveMaxPool2dWithIndices")
-        indices = Tensor(sizeO, Dtype.int64)
+        nhwc_stride = compute_nhwc_stride_2d(sizeO) if glob_vars.nhwc else None
+        indices = Tensor(sizeO, glob_vars.int_type, stride=nhwc_stride)
         ret = func(input.context_handle, out.tensor_handle, indices.tensor_handle,
                    input.tensor_handle, output_size)
         check_returncode(ret)
@@ -985,7 +992,7 @@ def stack(tensors, dim=0) -> Tensor:
 def sort(input, dim=- 1, descending=False, stable=False):
     vals = raw_like(input)
     sizeI = input.size()
-    indices = Tensor(sizeI, Dtype.int64)
+    indices = Tensor(sizeI, glob_vars.int_type)
 
     stable = c_void_p() if stable is None else pointer(c_bool(stable))
 
@@ -1000,7 +1007,7 @@ def topk(input, k, dim=-1, largest=True, sorted=True):
     sizeI = list(input.size())
     sizeI[dim] = k
     values = Tensor(sizeI, input.get_dtype())
-    indices = Tensor(sizeI, Dtype.int64)
+    indices = Tensor(sizeI, glob_vars.int_type)
 
     func = check_function("diopiTopk")
     ret = func(input.context_handle, values.tensor_handle,
@@ -1031,10 +1038,10 @@ def one_hot(input, num_classes=- 1):
     sizeI = input.size()
     if num_classes == -1:
         sizeI += (np.max(input.numpy()) + 1, )
-        out = Tensor(sizeI, Dtype.int64)
+        out = Tensor(sizeI, glob_vars.int_type)
     else:
         sizeI += (num_classes, )
-        out = Tensor(sizeI, Dtype.int64)
+        out = Tensor(sizeI, glob_vars.int_type)
 
     func = check_function("diopiOneHot")
     ret = func(input.context_handle, out.tensor_handle,
@@ -1303,7 +1310,7 @@ def max(input, dim, keepdim=False):
     else:
         del sizeI[dim]
     out = Tensor(sizeI, input.get_dtype())
-    indices = Tensor(out.size(), Dtype.int64)
+    indices = Tensor(out.size(), glob_vars.int_type)
 
     func = check_function("diopiMax")
     ret = func(input.context_handle, out.tensor_handle, indices.tensor_handle,
@@ -1409,7 +1416,8 @@ def roi_align(input, boxes, output_size, spatial_scale=1.0, sampling_ratio=-1, a
     sizeI[-1] = output_size[-1]
     sizeI[-2] = output_size[-2]
 
-    out = Tensor(sizeI, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_2d(sizeI) if glob_vars.nhwc else None
+    out = Tensor(sizeI, input.get_dtype(), stride=nhwc_stride)
     func = check_function("diopiRoiAlign")
     ret = func(input.context_handle, out.tensor_handle, input.tensor_handle,
                boxes.tensor_handle, c_double(spatial_scale), output_size[-2],
@@ -1929,7 +1937,7 @@ def arange(end, start=0, step=1, dtype=None) -> Tensor:
         if type(start) == float or type(end) == float or type(step) == float:
             dtype=Dtype.float32
         else:
-            dtype=Dtype.int64
+            dtype=glob_vars.int_type
     
     numel = int((end - start)/step)
     out = Tensor((numel,), dtype)
@@ -1941,7 +1949,7 @@ def arange(end, start=0, step=1, dtype=None) -> Tensor:
 
 
 def randperm(n :int, dtype=None) -> Tensor:
-    dtype = Dtype.int64 if dtype is None else dtype
+    dtype = glob_vars.int_type if dtype is None else dtype
     numel = n
     out = Tensor((numel,), dtype)
 
@@ -2160,7 +2168,7 @@ def reciprocal(input, inplace=False) -> Tensor:
 
 
 def bitwise_not(input):
-    assert (input.get_dtype() in [Dtype.bool, Dtype.int8, Dtype.int16, Dtype.int32, Dtype.int64]),\
+    assert (input.get_dtype() in [Dtype.bool, Dtype.int8, Dtype.int16, Dtype.int32, glob_vars.int_type]),\
         "input tensor must be of integral or boolean"
 
     out = raw_like(input)
@@ -2183,7 +2191,7 @@ def argmax(input, dim=None, keepdim=False):
         sizeO = [1]
         dim = c_void_p()
 
-    out = Tensor(sizeO, Dtype.int64)
+    out = Tensor(sizeO, glob_vars.int_type)
     func = check_function("diopiArgmax")
     ret = func(input.context_handle, out.tensor_handle, input.tensor_handle, dim, keepdim)
     check_returncode(ret)
@@ -2293,7 +2301,8 @@ def conv3d(input, weight, bias=None, stride=1,
     padding = Sizes(tuple(padding))
     dilation = Sizes(tuple(dilation))
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_3d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     func = check_function("diopiConvolution3d")
     ret = func(input.context_handle, out.tensor_handle, input.tensor_handle,
                weight.tensor_handle, bias, stride, padding, dilation, groups)
@@ -2594,7 +2603,8 @@ def adaptive_avg_pool3d(input, output_size):
         else:
             sizeO.append(output_size[i])
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_3d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     output_size = Sizes((sizeO[-3], sizeO[-2], sizeO[-1]))
 
     func = check_function("diopiAdaptiveAvgPool3d")
@@ -2634,12 +2644,14 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
         else:
             sizeO.append(output_size[i])
 
-    out = Tensor(sizeO, input.get_dtype())
+    nhwc_stride = compute_nhwc_stride_3d(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     output_size = Sizes(tuple(output_size))
 
     if return_indices:
         func = check_function("diopiAdaptiveMaxPool3dWithIndices")
-        indices = Tensor(sizeO, Dtype.int64)
+        nhwc_stride = compute_nhwc_stride_3d(sizeO) if glob_vars.nhwc else None
+        indices = Tensor(sizeO, glob_vars.int_type, stride=nhwc_stride)
         ret = func(input.context_handle, out.tensor_handle, indices.tensor_handle,
                    input.tensor_handle, output_size)
         check_returncode(ret)
@@ -2708,7 +2720,7 @@ def max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1,
         return out
     else:
         func = check_function("diopiMaxPool3dWithIndices")
-        indices = Tensor(sizeO, Dtype.int64)
+        indices = Tensor(sizeO, glob_vars.int_type)
         ret = func(input.context_handle, out.tensor_handle,
                    indices.tensor_handle, input.tensor_handle,
                    kernel_size, stride, padding, dilation, ceil_mode)
@@ -2931,7 +2943,10 @@ def interpolate(input, size, mode="nearest", align_corners=None) -> Tensor:
     sizeI = list(input.size())
     for i in range(len(size)):
         sizeI[-i - 1] = size[-i - 1]
-    out = Tensor(sizeI, input.get_dtype())
+
+
+    nhwc_stride = compute_nhwc_stride(sizeI) if glob_vars.nhwc else None
+    out = Tensor(sizeI, input.get_dtype(), stride=nhwc_stride)
 
     c_size = Sizes(tuple(size))
     if mode == "nearest":
@@ -2980,7 +2995,10 @@ def pad(input, pad, mode='constant', value=None):
         value = c_void_p()
     else:
         value = byref(c_double(value))
-    out = Tensor(sizeO, input.get_dtype())
+
+
+    nhwc_stride = compute_nhwc_stride(sizeO) if glob_vars.nhwc else None
+    out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
     func = check_function("diopiPad")
     ret = func(input.context_handle, out.tensor_handle, input.tensor_handle, pad, 
                mode.encode('UTF-8'), value)
@@ -2994,7 +3012,7 @@ def unique(input, sorted=True, return_inverse=False, return_counts=False, dim=No
         sizeI = list(input.size())
         if dim is not None:
             sizeI = (sizeI[dim], )
-        indices = Tensor(sizeI, Dtype.int64)
+        indices = Tensor(sizeI, glob_vars.int_type)
         indices_handle = indices.tensor_handle
     else:
         indices_handle = c_void_p()

--- a/python/conformance/diopi_runtime.py
+++ b/python/conformance/diopi_runtime.py
@@ -78,6 +78,53 @@ def to_numpy_dtype(dtype: Dtype) -> np.dtype:
         return None
 
 
+def compute_nhwc_stride_2d(sizes, itemsize=1):
+    dim = len(sizes)
+    strides = [itemsize for i in range(dim)]
+    assert dim == 3 or dim == 4, "not supported dim"
+    if dim == 3:
+        strides[0] = itemsize
+        strides[2] = strides[0] * sizes[0]
+        strides[1] = strides[2] * sizes[2]
+    elif dim == 4:
+        strides[1] = itemsize
+        strides[3] = strides[0] * sizes[1]
+        strides[2] = strides[3] * sizes[3]
+        strides[0] = strides[2] * sizes[2]
+    return strides
+
+
+def compute_nhwc_stride_3d(sizes, itemsize=1):
+    dim = len(sizes)
+    strides = [itemsize for i in range(dim)]
+    assert dim == 4 or dim == 5, "not supported dim"
+    if dim == 4:
+        strides[0] = itemsize
+        strides[3] = strides[0] * sizes[0]
+        strides[2] = strides[3] * sizes[3]
+        strides[1] = strides[2] * sizes[2]
+    elif dim == 5:
+        strides[1] = itemsize
+        strides[4] = strides[0] * sizes[1]
+        strides[3] = strides[4] * sizes[4]
+        strides[2] = strides[3] * sizes[3]
+        strides[0] = strides[2] * sizes[2]
+    return strides
+
+
+def compute_nhwc_stride(size, itemsize=1, name=None):
+    if name == '2d':
+        return compute_nhwc_stride_2d(size, itemsize)
+    if name == '3d':
+        return compute_nhwc_stride_3d(size, itemsize)
+
+    dim = len(size)
+    if dim < 5:
+        return compute_nhwc_stride_2d(size, itemsize)
+    else:
+        return compute_nhwc_stride_3d(size, itemsize)
+
+
 _cur_dir = os.path.dirname(os.path.abspath(__file__))
 diopirt_lib = cdll.LoadLibrary(os.path.join(_cur_dir, "../../lib/libdiopirt.so"))
 diopirt_lib.diopiInit()

--- a/python/main.py
+++ b/python/main.py
@@ -3,7 +3,7 @@ import argparse
 import shlex
 import conformance as cf
 from conformance.utils import is_ci, error_counter, DiopiException
-from conformance.utils import logger
+from conformance.utils import logger, nhwc_op, dtype_op, dtype_out_op, glob_vars
 from conformance.model_list import model_list, model_op_list
 
 
@@ -19,6 +19,12 @@ def parse_args():
                         help='The dtype in filter_dtype will not be processed')
     parser.add_argument('--get_model_list', action='store_true',
                         help='Whether return the supported model list')
+    parser.add_argument('--nhwc', action='store_true',
+                        help='Whether to use nhwc layout for partial tests')
+    parser.add_argument('--nhwc_min_dim', type=int, default=3,
+                        help='Whether to use nhwc layout for 3-dim Tensor')
+    parser.add_argument('--four_bytes', action='store_true',
+                        help='Whether to use 4-bytes data type for partial tests')
     args = parser.parse_args()
     return args
 
@@ -32,8 +38,16 @@ if __name__ == "__main__":
         for model_name in model_op_list.keys():
             op_list = model_op_list[model_name]
             print(f"The model {model_name}'s op_list: {op_list}")
-
         exit(0)
+
+    if args.nhwc:
+        print(f"The op_list using nhwc layout: {list(nhwc_op.keys())}",)
+        glob_vars.set_nhwc()
+        glob_vars.set_nhwc_min_dim(args.nhwc_min_dim)
+
+    if args.four_bytes:
+        print(f"The op_list using 32-bit type: {list(dtype_op.keys()) + list(dtype_out_op.keys())}")
+        glob_vars.set_four_bytes()
 
     if args.mode == 'gen_data':
         if args.model_name != '':


### PR DESCRIPTION
NHWC处理方案
1. run_test 阶段将numpy tensor转为nhwc格式输入， 因此gen_data的数据对于两种格式通用
（注意nv部分算子不支持nhwc，故无法从nv产生基准数据）
3. python接口创建相应的nhwc的out张量作为输出
4. backward测试阶段复用1，2转变后的张量，故也是nhwc格式
5. --nhwc启动，自动输出影响的算子清单

INT型数据处理方案
1. run_test 阶段将numpy tensor 从int64转为int32型， 因此gen_data的数据对于两种格式通用
（注意nv部分算子不支持int32，故无法从nv产生基准数据，经测试，转化对目前测试精度几乎无影响）
3. python接口创建相应的int32的out张量作为输出
4. --four_bytes启动，自动输出影响的算子清单