### PR TITLE
add test for op repeat

### DIFF
--- a/python/conformance/diopi_configs.py
+++ b/python/conformance/diopi_configs.py
@@ -3002,4 +3002,26 @@ diopi_configs = {
         saved_args=dict(output=0),
     ),
 
+    'repeat' : dict(
+        name=["repeat"],
+        interface=['CustomizedTest'],
+        para=dict(
+            repeats_size=[(4, 2), (4, 2, 1),
+                          (4, 2), (4, 2, 1),
+                          (4, 2, 1)],
+        ),
+        tensor_para=dict(
+            gen_fn=Genfunc.randn,
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((3, ), (3, ),
+                              (1, 2), (1, 2),
+                              (1, 2, 3)),
+                    "dtype": [Dtype.float32, Dtype.float64],
+                },
+            ]
+        ),
+    ),
+
 }

--- a/python/conformance/diopi_functions.py
+++ b/python/conformance/diopi_functions.py
@@ -3254,3 +3254,28 @@ def triangular_solve_backward(input, grad_outputs, output, A, upper=True, transp
                grad_cloned_mat, output.tensor_handle, input.tensor_handle, A.tensor_handle, c_bool(upper), c_bool(transpose), c_bool(unitriangular))
     check_returncode(ret)
     return {"input": grad_input, "A": grad_A}
+
+
+def repeat(input, repeats_size) -> Tensor:
+    sizeI = list(input.size())
+    lenSizeI = len(sizeI)
+    repeats_size = list(repeats_size)
+    lenRepeatsSize = len(repeats_size)
+
+    assert lenSizeI <= lenRepeatsSize, f'lenSizeI ({lenSizeI}) should <= lenRepeatsSize ({lenRepeatsSize})'
+    
+    output_size = []
+    for i in range(lenRepeatsSize):
+        k = repeats_size[i]
+        if lenSizeI + i >= lenRepeatsSize:
+            k *= sizeI[lenSizeI + i - lenRepeatsSize]
+        output_size.append(k)
+    sizeO = Sizes(output_size)
+
+    repeats_size = Sizes(repeats_size)
+
+    out = Tensor(output_size, input.get_dtype())
+    func = check_function("diopiRepeat")
+    ret = func(input.context_handle, out.tensor_handle, input.tensor_handle, repeats_size)
+    check_returncode(ret)
+    return out

--- a/python/conformance/gen_data.py
+++ b/python/conformance/gen_data.py
@@ -463,6 +463,10 @@ class CustomizedTest(object):
         import torch
         return torch.nn.Fold(output_size, kernel_size, dilation, padding, stride)(input)
 
+    def repeat(input, repeats_size):
+        import torch
+        return input.repeat(repeats_size)
+
 
 def transfer_tensor_to_device(function_paras: dict):
     import torch


### PR DESCRIPTION
1. repeat 的 torch 定义
https://pytorch.org/docs/1.10/generated/torch.Tensor.repeat.html?highlight=repeat


2. Parrots 中计算 out = repeat(input, repeat_size) 的输出 out 的 shape 的公式
- https://github.com/ParrotsDL/senseparrots/blob/master/src/compute/src/infers/otherInfer.cpp#L417
```
//===============================================
// infer repeat op
// don't support non-contiguous
//===============================================
void inferRepeat(const DArraySpec& inSpec, DArraySpec& outSpec, const std::vector<size_t>& repeats) {
    PARROTS_CHECKARGS(!inSpec.isNone());
    auto repeatsSize = repeats.size();
    PARROTS_CHECKARGS(inSpec.ndims() <= repeatsSize);
    vector_t<int64_t> outDims(repeatsSize);
    for (size_t i = 0; i < repeatsSize; ++i) {
        size_t k = repeats[i];
        if (inSpec.ndims() + i >= repeatsSize)
            k *= inSpec.dim(inSpec.ndims() + i - repeatsSize);
        outDims[i] = k;
    }
    outSpec = DArraySpec::array(outSpec.elemType(), DArrayShape::withDims(outDims.data(), outDims.size()));
}
```

本地测试，单元测试可以通过。